### PR TITLE
Crowd 3.0.1 compatibility

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -6,10 +6,6 @@ provisioner:
   require_chef_omnibus: 12.18.31
 
 platforms:
-  - name: ubuntu-12.04
-    run_list:
-    - recipe[apt]
-
   - name: ubuntu-14.04
     run_list:
     - recipe[apt]
@@ -27,5 +23,7 @@ suites:
     run_list:
     - recipe[crowd]
     attributes:
+      crowd:
+        version: 3.0.1
       apt:
         compile_time_update: true

--- a/libraries/crowd.rb
+++ b/libraries/crowd.rb
@@ -141,6 +141,9 @@ module Crowd
         '2.4.10' => {
           'tar' => 'fcb7dde464068c82558bb6baf6d86542a3aec3a18d8fe965a230a42290cd7e11'
         },
+		'3.0.0' => {
+		  'tar' => 'ff8d62481f3df7d84ee9e030f2d4472ab4d59f81768217f7155638c4c272e291'
+		},
 		'3.0.1' => {
 		  'tar' => '9987f758084006cfba75f6eb77f43315a5f25aed86a7f5f7d280ecf65f06ff9e'
 		}

--- a/libraries/crowd.rb
+++ b/libraries/crowd.rb
@@ -140,7 +140,10 @@ module Crowd
         },
         '2.4.10' => {
           'tar' => 'fcb7dde464068c82558bb6baf6d86542a3aec3a18d8fe965a230a42290cd7e11'
-        }
+        },
+		'3.0.1' => {
+		  'tar' => '9987f758084006cfba75f6eb77f43315a5f25aed86a7f5f7d280ecf65f06ff9e'
+		}
       }
     end
     # rubocop:enable Metrics/MethodLength


### PR DESCRIPTION
Not much done, but the new Crowd 3.0.0 and 3.0.1 versions can be deployed.
Also removed Ubuntu 12.04 due EOL.